### PR TITLE
Allow natural spawning of roaches to be disabled

### DIFF
--- a/src/main/java/io/github/aelpecyem/la_cucaracha/LaCucaracha.java
+++ b/src/main/java/io/github/aelpecyem/la_cucaracha/LaCucaracha.java
@@ -99,12 +99,14 @@ public class LaCucaracha implements ModInitializer {
 			roachSpawner.spawn(world, world.getDifficulty() != Difficulty.PEACEFUL, server.shouldSpawnAnimals());
 		});
 		ServerEntityCombatEvents.AFTER_KILLED_OTHER_ENTITY.register((world, entity, killedEntity) -> {
-			RandomGenerator random = killedEntity.getRandom();
-			if (killedEntity.getType().isIn(ROACH_CARRIERS) && random.nextInt(8) == 0) {
-				RoachEntity.spawnRoaches(world, entity instanceof LivingEntity l ? l : null,
-										 killedEntity.getPos().add(0, killedEntity.getHeight() / 2, 0),
-										 random, 1 + random.nextInt(3), false);
-				sendRoachPotionPacket(world, killedEntity.getPos().add(0, killedEntity.getHeight() / 2, 0));
+			if (LaCucarachaConfig.roachSpawnEnabledCarriers) {
+				RandomGenerator random = killedEntity.getRandom();
+				if (killedEntity.getType().isIn(ROACH_CARRIERS) && random.nextInt(8) == 0) {
+					RoachEntity.spawnRoaches(world, entity instanceof LivingEntity l ? l : null,
+							killedEntity.getPos().add(0, killedEntity.getHeight() / 2, 0),
+							random, 1 + random.nextInt(3), false);
+					sendRoachPotionPacket(world, killedEntity.getPos().add(0, killedEntity.getHeight() / 2, 0));
+				}
 			}
 		});
 	}

--- a/src/main/java/io/github/aelpecyem/la_cucaracha/LaCucarachaConfig.java
+++ b/src/main/java/io/github/aelpecyem/la_cucaracha/LaCucarachaConfig.java
@@ -3,8 +3,17 @@ package io.github.aelpecyem.la_cucaracha;
 import eu.midnightdust.lib.config.MidnightConfig;
 
 public class LaCucarachaConfig extends MidnightConfig {
+	@Entry
+	public static boolean roachSpawnEnabledCarriers = true;
+
+	@Entry
+	public static boolean roachSpawnEnabledStructures = true;
+
 	@Entry(min = 1, max = Integer.MAX_VALUE)
 	public static int roachSpawnIntervalStructures = 100;
+
+	@Entry
+	public static boolean roachSpawnEnabledFood = true;
 
 	@Entry(min = 1, max = Integer.MAX_VALUE)
 	public static int roachSpawnIntervalFood = 100;

--- a/src/main/java/io/github/aelpecyem/la_cucaracha/RoachSpawner.java
+++ b/src/main/java/io/github/aelpecyem/la_cucaracha/RoachSpawner.java
@@ -29,29 +29,34 @@ public class RoachSpawner implements Spawner {
 
 	public int spawn(ServerWorld world, boolean spawnMonsters, boolean spawnAnimals) {
 		if (spawnAnimals && world.getGameRules().getBoolean(GameRules.DO_MOB_SPAWNING)) {
-			--this.ticksUntilNextFoodSpawn;
-			--this.ticksUntilNextStructureSpawn;
-			if (this.ticksUntilNextFoodSpawn <= 0) {
-				this.ticksUntilNextFoodSpawn = LaCucarachaConfig.roachSpawnIntervalFood;
-				RandomGenerator random = world.random;
-				world.getPlayers().forEach(serverPlayerEntity -> {
-					BlockPos blockPos = getRandomSpawnPos(random, serverPlayerEntity, true);
+			if (LaCucarachaConfig.roachSpawnEnabledFood) {
+				--this.ticksUntilNextFoodSpawn;
+				if (this.ticksUntilNextFoodSpawn <= 0) {
+					this.ticksUntilNextFoodSpawn = LaCucarachaConfig.roachSpawnIntervalFood;
+					RandomGenerator random = world.random;
+					world.getPlayers().forEach(serverPlayerEntity -> {
+						BlockPos blockPos = getRandomSpawnPos(random, serverPlayerEntity, true);
 
-					if (RoachEntity.canMobSpawn(LaCucaracha.ROACH_ENTITY_TYPE, world, SpawnReason.NATURAL, blockPos, world.getRandom())) {
-						spawnFromFood(world, blockPos);
-					}
-				});
+						if (RoachEntity.canMobSpawn(LaCucaracha.ROACH_ENTITY_TYPE, world, SpawnReason.NATURAL, blockPos, world.getRandom())) {
+							spawnFromFood(world, blockPos);
+						}
+					});
+				}
 			}
-			if (this.ticksUntilNextStructureSpawn <= 0) {
-				this.ticksUntilNextStructureSpawn = LaCucarachaConfig.roachSpawnIntervalStructures;
-				RandomGenerator random = world.random;
-				world.getPlayers().forEach(serverPlayerEntity -> {
-					BlockPos blockPos = getRandomSpawnPos(random, serverPlayerEntity, false);
 
-					if (RoachEntity.canMobSpawn(LaCucaracha.ROACH_ENTITY_TYPE, world, SpawnReason.NATURAL, blockPos, world.getRandom())) {
-						spawnFromStructure(world, blockPos);
-					}
-				});
+			if (LaCucarachaConfig.roachSpawnEnabledStructures) {
+				--this.ticksUntilNextStructureSpawn;
+				if (this.ticksUntilNextStructureSpawn <= 0) {
+					this.ticksUntilNextStructureSpawn = LaCucarachaConfig.roachSpawnIntervalStructures;
+					RandomGenerator random = world.random;
+					world.getPlayers().forEach(serverPlayerEntity -> {
+						BlockPos blockPos = getRandomSpawnPos(random, serverPlayerEntity, false);
+
+						if (RoachEntity.canMobSpawn(LaCucaracha.ROACH_ENTITY_TYPE, world, SpawnReason.NATURAL, blockPos, world.getRandom())) {
+							spawnFromStructure(world, blockPos);
+						}
+					});
+				}
 			}
 		}
 

--- a/src/main/resources/assets/la_cucaracha/lang/en_us.json
+++ b/src/main/resources/assets/la_cucaracha/lang/en_us.json
@@ -9,7 +9,10 @@
   "subtitles.la_cucaracha.roach.hurt": "Roach hurts",
   "subtitles.la_cucaracha.roach.death": "Roach dies",
   "la_cucaracha.midnightconfig.title": "La Cucaracha Config",
+  "la_cucaracha.midnightconfig.roachSpawnEnabledCarriers": "Roach Spawn Enabled (Carrier Mobs)",
+  "la_cucaracha.midnightconfig.roachSpawnEnabledStructures": "Roach Spawn Enabled (Structures)",
   "la_cucaracha.midnightconfig.roachSpawnIntervalStructures": "Roach Spawn Interval (Structures)",
+  "la_cucaracha.midnightconfig.roachSpawnEnabledFood": "Roach Spawn Enabled (Food)",
   "la_cucaracha.midnightconfig.roachSpawnIntervalFood": "Roach Spawn Interval (Food)",
   "la_cucaracha.midnightconfig.roachMaxGroupSize": "Naturally Spawned Roach Group Limit",
   "la_cucaracha.midnightconfig.roachAggressionGroupSize": "Roach Swarm Mode Group Size"


### PR DESCRIPTION
Intended for ModFest: Singularity, to prevent roaches spawning outside of their designated booth and messing with the experience of other booths or startling players who would rather avoid this mod.

Technically, spawning from carrier mobs and structures can already be disabled by blanking the related tags, but spawning from dropped food could not be configured.